### PR TITLE
feat(tags): get all tags api

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UserModule } from './user/user.module';
 import { ConfigModule } from '@nestjs/config';
 import { ProfilesModule } from './profiles/profiles.module';
 import { ArticlesModule } from './articles/articles.module';
+import { TagsModule } from './tags/tags.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { ArticlesModule } from './articles/articles.module';
     }),
     ProfilesModule,
     ArticlesModule,
+    TagsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/tags/tags.controller.spec.ts
+++ b/src/tags/tags.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagsController } from './tags.controller';
+import { TagsService } from './tags.service';
+
+describe('TagsController', () => {
+  let controller: TagsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagsController],
+      providers: [TagsService],
+    }).compile();
+
+    controller = module.get<TagsController>(TagsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { TagsService } from './tags.service';
+
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @Get()
+  getTags() {
+    return this.tagsService.getTags();
+  }
+}

--- a/src/tags/tags.module.ts
+++ b/src/tags/tags.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+
+@Module({
+  controllers: [TagsController],
+  providers: [TagsService],
+})
+export class TagsModule {}

--- a/src/tags/tags.service.spec.ts
+++ b/src/tags/tags.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagsService } from './tags.service';
+
+describe('TagsService', () => {
+  let service: TagsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TagsService],
+    }).compile();
+
+    service = module.get<TagsService>(TagsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Injectable()
+export class TagsService {
+  constructor(private prisma: PrismaService) {}
+
+  async getTags() {
+    const tags = await this.prisma.article.findMany({
+      select: {
+        tagList: true,
+      },
+    });
+    const flatTags = tags.flatMap((article) => article.tagList);
+    return [...new Set(flatTags)];
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a new API endpoint to fetch all unique tags from articles by implementing a TagsModule with a service and controller. Include unit tests for the service and controller to verify functionality.

New Features:
- Introduce a new API endpoint to retrieve all unique tags from articles.

Tests:
- Add unit tests for the TagsService and TagsController to ensure the new API endpoint functions correctly.